### PR TITLE
Respect the intent of the user

### DIFF
--- a/lib/action_view/link_to_blank/link_to_blank.rb
+++ b/lib/action_view/link_to_blank/link_to_blank.rb
@@ -13,7 +13,7 @@ module LinkToBlank
             html_options = args[2] || {}
 
             # override
-            html_options.merge!(target: '_blank')
+            html_options.reverse_merge! target: '_blank'
 
             link_to(name, options, html_options)
           end

--- a/test/test_actionview-link_to_blank.rb
+++ b/test/test_actionview-link_to_blank.rb
@@ -270,6 +270,10 @@ class TestActionViewLinkToBlank < MiniTest::Unit::TestCase
       link_to_blank("Malicious <script>content</script>".html_safe, "/")
   end
 
+  def test_link_tag_override_specific
+    assert_dom_equal %{<a href="http://www.example.com" target="override">Hello</a>}, link_to_blank("Hello", "http://www.example.com", target: 'override')
+  end
+
   private
     # MiniTest does not have build_message method, so I copy from below:
     # https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/assertions/dom.rb


### PR DESCRIPTION
https://github.com/sanemat/actionview-link_to_blank/issues/9

```
link_to_blank('foo', target: '_parent')
#=> <a href="foo" target="_parent">
```
