### PR TITLE
[pend] Use Minitest::Test instead of MiniTest::Unit::TestCase

### DIFF
--- a/test/test_actionview-link_to_blank.rb
+++ b/test/test_actionview-link_to_blank.rb
@@ -22,7 +22,7 @@ module RenderERBUtils
   end
 end
 
-class TestActionViewLinkToBlank < MiniTest::Unit::TestCase
+class TestActionViewLinkToBlank < Minitest::Test
 
   # In a few cases, the helper proxies to 'controller'
   # or request.


### PR DESCRIPTION
rails4.0がminitest 4に絞っている(not minitest 5)ので、rails4.0系に適用できない
