### PR TITLE
Add test requirement

### DIFF
--- a/test/test_actionview-link_to_blank.rb
+++ b/test/test_actionview-link_to_blank.rb
@@ -4,6 +4,7 @@ Coveralls.wear!
 
 require 'minitest/autorun'
 require 'active_support/concern'
+require 'active_support/deprecation'
 require 'active_support/core_ext'
 require 'active_support/testing/deprecation'
 require 'action_view'


### PR DESCRIPTION
In activesupport, `require 'active_support/core_ext'` brings `uninitialized const ActiveSupport::Deprecation::MethodWrapper (NameError)`.

```
/Users/sane/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/rails-078da2b22de7/activesupport/lib/active_support/deprecation.rb:26:in `<
class:Deprecation>': uninitialized constant ActiveSupport::Deprecation::MethodWrapper (NameError)  
        from /Users/sane/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/rails-078da2b22de7/activesupport/lib/active_support/deprecatio
n.rb:6:in `<module:ActiveSupport>'
```
