### PR TITLE
Correct cherry-pick from active_support

### DIFF
--- a/test/test_actionview-link_to_blank.rb
+++ b/test/test_actionview-link_to_blank.rb
@@ -3,6 +3,7 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'minitest/autorun'
+require 'active_support'
 require 'active_support/concern'
 require 'active_support/deprecation'
 require 'active_support/core_ext'


### PR DESCRIPTION
uninitialized constant ActiveSupport::Autoload (NameError), sometimes,
at ramdom
https://github.com/rails/rails/issues/14664
